### PR TITLE
Bdimcheff version

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -9,6 +9,11 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// LogrusGoKitLogger is the concrete implementation of the logging wrapper
+type LogrusGoKitLogger struct {
+	logrusLogger
+}
+
 type logrusLogger interface {
 	WithFields(fields logrus.Fields) *logrus.Entry
 }
@@ -18,10 +23,7 @@ func NewLogrusGoKitLogger(logger logrusLogger) *LogrusGoKitLogger {
 	return &LogrusGoKitLogger{logger}
 }
 
-// LogrusGoKitLogger is the concrete implementation of the logging wrapper
-type LogrusGoKitLogger struct {
-	logrusLogger
-}
+
 
 const msgKey = "msg"
 const errKey = "err"

--- a/logger.go
+++ b/logger.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// LogrusGoKitLogger is the concrete implementation of the logging wrapper
+// LogrusGoKitLogger is a gokit-compatible wrapper for logrus.LogrusGoKitLogger
 type LogrusGoKitLogger struct {
 	logrusLogger
 }
@@ -18,12 +18,10 @@ type logrusLogger interface {
 	WithFields(fields logrus.Fields) *logrus.Entry
 }
 
-// NewLogrusGoKitLogger wraps a logrus instance and implements the GoKit Logger interface
+// NewStackdriverLogger creates a gokit-compatible logger
 func NewLogrusGoKitLogger(logger logrusLogger) *LogrusGoKitLogger {
 	return &LogrusGoKitLogger{logger}
 }
-
-
 
 const msgKey = "msg"
 const errKey = "err"

--- a/logger.go
+++ b/logger.go
@@ -24,7 +24,10 @@ func NewLogrusGoKitLogger(logger logrusLogger) *LogrusGoKitLogger {
 }
 
 const msgKey = "msg"
+const messageKey = "message"
 const errKey = "err"
+const errorKey = "error"
+const severityKey = "severity"
 const levelKey = "level"
 
 // Log implements the fundamental Logger interface
@@ -40,44 +43,46 @@ func (l LogrusGoKitLogger) Log(keyvals ...interface{}) error {
 // extractLogElements iterates through the keyvals to form well
 // structuredkey:value pairs that Logrus expects. It also checks for keys with
 // special meaning like "msg" and "level" to format the log entry
-func (l LogrusGoKitLogger) extractLogElements(keyvals ...interface{}) (fields logrus.Fields, level logrus.Level, msg string) {
+func (l LogrusGoKitLogger) extractLogElements(keyVals ...interface{}) (fields logrus.Fields, level logrus.Level, msg string) {
 	msg = ""
 	fields = logrus.Fields{}
 	level = logrus.DebugLevel
 
-	for i := 0; i < len(keyvals); i += 2 {
-		if i+1 < len(keyvals) {
+	for i := 0; i < len(keyVals); i += 2 {
+		fieldKey := fmt.Sprint(keyVals[i])
+		if i+1 < len(keyVals) {
 
-			if fmt.Sprint(keyvals[i]) == msgKey && msg == "" {
+			fieldValue := fmt.Sprint(keyVals[i+1])
+			if (fieldKey == msgKey || fieldKey == messageKey) && msg == "" {
 				// if this is a "msg" key, store it separately so we can use it as the
 				// main log message
-				msg = fmt.Sprint(keyvals[i+1])
-			} else if fmt.Sprint(keyvals[i]) == errKey {
+				msg = fieldValue
+			} else if (fieldKey == errKey || fieldKey == errorKey) {
 				// if this is a "err" key, we should use the error message as
 				// the main message and promote the level to Error
-				err := fmt.Sprint(keyvals[i+1])
+				err := fieldValue
 				if err != "" {
 					msg = err
 					level = logrus.ErrorLevel
 				}
-			} else if fmt.Sprint(keyvals[i]) == levelKey {
+			} else if fieldKey == levelKey || fieldKey == severityKey {
 				// if this is a "level" key, it means GoKit logger is giving us
 				// a hint to the logging level
-				levelStr := fmt.Sprint(keyvals[i+1])
+				levelStr := fieldValue
 				parsedLevel, err := logrus.ParseLevel(levelStr)
 				if err != nil || level < parsedLevel {
 					level = logrus.ErrorLevel
-					fields["level"] = levelStr
+					fields[levelKey] = levelStr
 				} else {
 					level = parsedLevel
 				}
 			} else {
 				// this is just regular log data, add it as a key:value pair
-				fields[fmt.Sprint(keyvals[i])] = keyvals[i+1]
+				fields[fieldKey] = keyVals[i+1]
 			}
 		} else {
 			// odd pair key, with no matching value
-			fields[fmt.Sprint(keyvals[i])] = gokitlog.ErrMissingValue
+			fields[fieldKey] = gokitlog.ErrMissingValue
 		}
 	}
 	return

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,67 @@
+package stackdriver
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockLogrusLogger struct{}
+
+func (l *mockLogrusLogger) GetLevel() logrus.Level {
+	return logrus.DebugLevel
+}
+
+func (l *mockLogrusLogger) WithFields(fields logrus.Fields) *logrus.Entry {
+	return &logrus.Entry{}
+}
+
+func TestLogrusGoKitLogger_extractLogElements_basic(t *testing.T) {
+
+	mockLogrus := &mockLogrusLogger{}
+	logger := &LogrusGoKitLogger{mockLogrus}
+
+	fields, level, msg := logger.extractLogElements("msg", "testy mctestface", "level", "error", "foo", "bar", "number", 42, "flag", true)
+
+	expectedFields := logrus.Fields{}
+	expectedFields["foo"] = "bar"
+	expectedFields["number"] = 42
+	expectedFields["flag"] = true
+
+	assert.Equal(t, expectedFields, fields)
+	assert.Equal(t, logrus.ErrorLevel, level)
+	assert.Equal(t, "testy mctestface", msg)
+}
+
+func TestLogrusGoKitLogger_extractLogElements_defaultLevel(t *testing.T) {
+
+	mockLogrus := &mockLogrusLogger{}
+	logger := &LogrusGoKitLogger{mockLogrus}
+
+	fields, level, msg := logger.extractLogElements("msg", "testy mctestface")
+
+	expectedFields := logrus.Fields{}
+
+	assert.Equal(t, expectedFields, fields)
+	assert.Equal(t, logrus.DebugLevel, level)
+	assert.Equal(t, "testy mctestface", msg)
+}
+
+func TestLogrusGoKitLogger_extractLogElements_errorOverride(t *testing.T) {
+
+	mockLogrus := &mockLogrusLogger{}
+	logger := &LogrusGoKitLogger{mockLogrus}
+
+	fields, level, msg := logger.extractLogElements("err", "test error", "msg", "some message", "level", "debug", "number", 42, "flag", true)
+
+	expectedFields := logrus.Fields{}
+	expectedFields["msg"] = "some message"
+	expectedFields["level"] = "debug"
+	expectedFields["number"] = 42
+	expectedFields["flag"] = true
+
+	assert.Equal(t, expectedFields, fields)
+	assert.Equal(t, logrus.ErrorLevel, level)
+	assert.Equal(t, "test error", msg)
+}


### PR DESCRIPTION
@bdimcheff If you get a chance, I'd be very interested in why you chose:
```
type LogrusGoKitLogger struct {
	logrusLogger
}

type logrusLogger interface {
	WithFields(fields logrus.Fields) *logrus.Entry
}

func NewLogrusGoKitLogger(logger logrusLogger) *LogrusGoKitLogger {
	return &LogrusGoKitLogger{logger}
}
```
vs.
```
type LogrusGoKitLogger struct {
	Logger *logrus.Logger
}

func NewLogrusGoKitLogger(w io.Writer, opts ...Option) *LogrusGoKitLogger {
	logger := logrus.New()
	logger.SetFormatter(NewFormatter(opts...))
	logger.SetOutput(w)
	return &LogrusGoKitLogger{Logger: logger}
}
```
> we try very hard to avoid dependencies on concrete types in other packages (particularly third-party packages) unless they’re purely data and not behavior
so basically any case where we’re calling a function in a third-party package, it’s gonna be an interface so we can stub it for testing
> it keeps you honest and makes it explicit what you actually depend on in third-party code
we have this kind of stuff fairly frequently, for instance:

```
type notifier interface {
    Notify(error, ...interface{}) error
}

type logger interface {
    Log(keyvals ...interface{}) error
}
```

not that `...interface{}` is always a good idea, but any logging or notification (eg. bugsnag/sentry) use those interfaces and they can be stubbed out wherever
we do this a ton too for anything that does http:
```
type HTTPRequester interface {
    Do(*http.Request) (*http.Response, error)
}
```
> go idioms often call this Doer but that upset people who have java experience so we settled on HTTPRequester which is like halfway between Doer and HTTPEnterpriseFactoryBean or whatever 

> then we can swap out/inject different low-level http stuff for tests or in prod inject a logging http client or a retrying http client
> anyhow, interfaces :tada: