### PR TITLE
Map logrus trace to debug level

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -34,6 +34,7 @@ var levelsToSeverity = map[logrus.Level]severity{
 	logrus.ErrorLevel: severityError,
 	logrus.FatalLevel: severityCritical,
 	logrus.PanicLevel: severityAlert,
+	logrus.TraceLevel: severityDebug,
 }
 
 // log entries containing this type are evaluated as long entries as though all


### PR DESCRIPTION
There is a missing mapping of `logrus.TraceLevel`, which results in not including a log level in the GCP Stackdriver (defaulting to `severity=ERROR`). I am happy to adjust/improve.